### PR TITLE
Two Irrelevant Suggestions

### DIFF
--- a/src/posts/check-tmux-session-exists-script/index.md
+++ b/src/posts/check-tmux-session-exists-script/index.md
@@ -17,10 +17,8 @@ We can check if the session already exists before creating one. If a session alr
 session="workspace"
 
 # Check if the session exists, discarding output
-# We can check $? for the exit status (zero for success, non-zero for failure)
-tmux has-session -t $session 2>/dev/null
-
-if [ $? != 0 ]; then
+# "if" statements use the exit status of a program
+if tmux has-session -t $session 2>/dev/null; then
   # Set up your session
 fi
 


### PR DESCRIPTION
Hi,

I found your article helpful (I didn't know about `tmux has-session`.) I don't know whether this may still be of interest to you, but

* `if` statements use the exit status of a program (usually `test` in it's `[ ]` or `[[ ]]` forms) which is why it is possible to do something like:
  ```bash
  $ [[ 1 -eq 1 ]] && echo "True"
  True
  ```
* Use `exec` to automatically end bash when detaching from or exiting the session:
  ```bash
  exec tmux attach-session -t $session
  ```